### PR TITLE
Добавлен запускатель oscript. Fix xDrivenDevelopment/1c-syntax#26

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,54 @@
+`use strict`;
+
+exports.provideBuilder = function () {
+    return {
+        constructor: function (cwd) {
+            this.cwd = cwd;
+        },
+
+        getNiceName: function () {
+            return "1C (BSL)";
+        },
+
+        isEligable: function (cwd) {
+            console.log(cwd);
+            console.log("все хорошо");
+            return true;
+            var textEditor = atom.workspace.getActiveTextEditor();
+            if (!textEditor || !textEditor.getPath()) {
+                console.log("ошибка 1");
+                return false;
+            };
+            var path = textEditor.getPath();
+            console.log(path);
+            return path.endsWith(".os") || path.endsWith(".bsl");
+        },
+
+        settings: function (cwd) {
+
+            return [
+                {
+                    name: "OneScript: run",
+                    sh: false,
+                    exec: "oscript",
+                    args: [ "-encoding=utf-8", "{FILE_ACTIVE}" ],
+                    errorMatch: [
+                        "^\\{Модуль (?<file>.+) / Ошибка в строке: (?<line>[0-9]+) / (?<message>.*)\\}$"
+                    ]
+                },
+                {
+                    name: "OneScript: compile",
+                    sh: false,
+                    exec: "oscript",
+                    args: [ "-encoding=utf-8", "-compile", "{FILE_ACTIVE}" ]
+                },
+                {
+                    name: "OneScript: make",
+                    sh: false,
+                    exec: "oscript",
+                    args: [ "-encoding=utf-8", "-make", "{FILE_ACTIVE}" ]
+                }
+            ];
+        }
+    }
+};

--- a/package.json
+++ b/package.json
@@ -13,5 +13,14 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "providedServices": {
+      "builder": {
+        "description": "Builds 1C (BSL) files with OneScript",
+        "versions": {
+          "1.0.0": "provideBuilder"
+        }
+      }
+    },
+    "main": "lib/main.js"
 }


### PR DESCRIPTION
Добавлен функционал для запуска oscript.
Для работы запускатора необходим пакет [build](https://atom.io/packages/build) - необходимо отразить это в readme.

Доступно 3 команды. Указатель на строку ошибки пока не работает. Возможно из-за ограничения на расположение файла по `cwd` https://github.com/noseglid/atom-build/blob/master/README.md#error-matching

Думаю, @artbear будет рад :)

![1](https://cloud.githubusercontent.com/assets/1132840/11742406/baad3af2-a010-11e5-81ca-15bbfbf7c5fb.PNG)
![2](https://cloud.githubusercontent.com/assets/1132840/11742392/9fb1ee28-a010-11e5-891b-9b35750648f9.png)
![3](https://cloud.githubusercontent.com/assets/1132840/11742395/a1698258-a010-11e5-856e-1231d981a567.PNG)
